### PR TITLE
Move Reset All Progress button to header stats section

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -323,14 +323,15 @@ footer {
 .reset-link {
     background: none;
     border: none;
-    color: #999;
+    color: rgba(255, 255, 255, 0.8);
     font-size: 0.85rem;
     cursor: pointer;
     transition: color 0.3s ease;
 }
 
 .reset-link:hover {
-    color: #f12711;
+    color: white;
+    text-decoration: underline;
 }
 
 /* Streak indicator */

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,8 @@
                     <span id="mastered-count">0</span> / <span id="total-count">500</span> words mastered
                     <span class="separator">|</span>
                     <span id="accuracy">0</span>% accuracy
+                    <span class="separator">|</span>
+                    <button id="reset-progress-btn" class="reset-link">Reset All Progress</button>
                 </div>
             </div>
         </header>
@@ -64,9 +66,6 @@
             </div>
         </main>
 
-        <footer>
-            <button id="reset-progress-btn" class="reset-link">Reset All Progress</button>
-        </footer>
     </div>
 
     <script src="/static/app.js"></script>


### PR DESCRIPTION
Relocated the reset button from the footer to the right of the accuracy display in the header for better visibility and accessibility. Updated styling to match the header's white-on-orange color scheme.

https://claude.ai/code/session_01Ka7ckYeypWZW8dMqarZeyU