### PR TITLE
Remove PostgreSQL database dependency; use JSON file storage only

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,61 +8,6 @@ app = Flask(__name__)
 
 WORDS_FILE = 'words.json'
 PROGRESS_FILE = 'user_progress.json'
-DATABASE_URL = os.environ.get('DATABASE_URL')
-
-# Only import psycopg2 if we have a database URL
-if DATABASE_URL:
-    import psycopg2
-    from psycopg2.extras import RealDictCursor
-
-def get_db_connection():
-    """Get a database connection."""
-    conn = psycopg2.connect(DATABASE_URL)
-    return conn
-
-def init_db():
-    """Initialize database tables."""
-    conn = get_db_connection()
-    cur = conn.cursor()
-
-    # Create user_stats table
-    cur.execute('''
-        CREATE TABLE IF NOT EXISTS user_stats (
-            id INTEGER PRIMARY KEY DEFAULT 1,
-            total_practiced INTEGER DEFAULT 0,
-            total_correct INTEGER DEFAULT 0,
-            session_count INTEGER DEFAULT 1,
-            last_session TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-        )
-    ''')
-
-    # Create word_progress table
-    cur.execute('''
-        CREATE TABLE IF NOT EXISTS word_progress (
-            word_id INTEGER PRIMARY KEY,
-            times_shown INTEGER DEFAULT 0,
-            times_correct INTEGER DEFAULT 0,
-            streak INTEGER DEFAULT 0,
-            mastered BOOLEAN DEFAULT FALSE,
-            first_attempt_correct BOOLEAN DEFAULT NULL
-        )
-    ''')
-
-    # Add first_attempt_correct column if it doesn't exist (for existing databases)
-    cur.execute('''
-        ALTER TABLE word_progress ADD COLUMN IF NOT EXISTS first_attempt_correct BOOLEAN DEFAULT NULL
-    ''')
-
-    # Insert default user_stats if not exists
-    cur.execute('''
-        INSERT INTO user_stats (id, total_practiced, total_correct, session_count)
-        VALUES (1, 0, 0, 1)
-        ON CONFLICT (id) DO NOTHING
-    ''')
-
-    conn.commit()
-    cur.close()
-    conn.close()
 
 def load_words():
     with open(WORDS_FILE, 'r', encoding='utf-8') as f:
@@ -87,128 +32,21 @@ def save_progress_json(progress):
     with open(PROGRESS_FILE, 'w', encoding='utf-8') as f:
         json.dump(progress, f, indent=2, ensure_ascii=False)
 
-def load_progress_db():
-    """Load progress from PostgreSQL."""
-    conn = get_db_connection()
-    cur = conn.cursor(cursor_factory=RealDictCursor)
-
-    # Get user stats
-    cur.execute('SELECT * FROM user_stats WHERE id = 1')
-    stats_row = cur.fetchone()
-
-    if not stats_row:
-        user_stats = {
-            'total_practiced': 0,
-            'total_correct': 0,
-            'session_count': 1,
-            'last_session': datetime.now().isoformat()
-        }
-    else:
-        user_stats = {
-            'total_practiced': stats_row['total_practiced'],
-            'total_correct': stats_row['total_correct'],
-            'session_count': stats_row['session_count'],
-            'last_session': stats_row['last_session'].isoformat() if stats_row['last_session'] else datetime.now().isoformat()
-        }
-
-    # Get word progress
-    cur.execute('SELECT * FROM word_progress')
-    word_rows = cur.fetchall()
-
-    word_progress = {}
-    for row in word_rows:
-        word_progress[str(row['word_id'])] = {
-            'times_shown': row['times_shown'],
-            'times_correct': row['times_correct'],
-            'streak': row['streak'],
-            'mastered': row['mastered'],
-            'first_attempt_correct': row.get('first_attempt_correct')
-        }
-
-    cur.close()
-    conn.close()
-
-    return {
-        'user_stats': user_stats,
-        'word_progress': word_progress
-    }
-
-def save_word_progress(word_id, wp):
-    """Save progress for a single word."""
-    conn = get_db_connection()
-    cur = conn.cursor()
-
-    cur.execute('''
-        INSERT INTO word_progress (word_id, times_shown, times_correct, streak, mastered, first_attempt_correct)
-        VALUES (%s, %s, %s, %s, %s, %s)
-        ON CONFLICT (word_id) DO UPDATE SET
-            times_shown = EXCLUDED.times_shown,
-            times_correct = EXCLUDED.times_correct,
-            streak = EXCLUDED.streak,
-            mastered = EXCLUDED.mastered,
-            first_attempt_correct = EXCLUDED.first_attempt_correct
-    ''', (int(word_id), wp['times_shown'], wp['times_correct'], wp['streak'], wp['mastered'], wp.get('first_attempt_correct')))
-
-    conn.commit()
-    cur.close()
-    conn.close()
-
-def update_user_stats(is_correct):
-    """Update user stats after an answer."""
-    conn = get_db_connection()
-    cur = conn.cursor()
-
-    if is_correct:
-        cur.execute('''
-            UPDATE user_stats
-            SET total_practiced = total_practiced + 1,
-                total_correct = total_correct + 1,
-                last_session = CURRENT_TIMESTAMP
-            WHERE id = 1
-        ''')
-    else:
-        cur.execute('''
-            UPDATE user_stats
-            SET total_practiced = total_practiced + 1,
-                last_session = CURRENT_TIMESTAMP
-            WHERE id = 1
-        ''')
-
-    conn.commit()
-    cur.close()
-    conn.close()
-
-# Wrapper functions that choose DB or JSON based on environment
 def load_progress():
-    if DATABASE_URL:
-        return load_progress_db()
     return load_progress_json()
 
 def save_progress(word_id, wp, is_correct):
-    if DATABASE_URL:
-        save_word_progress(word_id, wp)
-        update_user_stats(is_correct)
-    else:
-        progress = load_progress_json()
-        progress['word_progress'][word_id] = wp
-        progress['user_stats']['total_practiced'] += 1
-        if is_correct:
-            progress['user_stats']['total_correct'] += 1
-        progress['user_stats']['last_session'] = datetime.now().isoformat()
-        save_progress_json(progress)
+    progress = load_progress_json()
+    progress['word_progress'][word_id] = wp
+    progress['user_stats']['total_practiced'] += 1
+    if is_correct:
+        progress['user_stats']['total_correct'] += 1
+    progress['user_stats']['last_session'] = datetime.now().isoformat()
+    save_progress_json(progress)
 
 def reset_all_progress():
-    if DATABASE_URL:
-        conn = get_db_connection()
-        cur = conn.cursor()
-        cur.execute('DELETE FROM word_progress')
-        cur.execute('UPDATE user_stats SET total_practiced = 0, total_correct = 0, session_count = 1, last_session = CURRENT_TIMESTAMP WHERE id = 1')
-        conn.commit()
-        cur.close()
-        conn.close()
-    else:
-        if os.path.exists(PROGRESS_FILE):
-            os.remove(PROGRESS_FILE)
+    if os.path.exists(PROGRESS_FILE):
+        os.remove(PROGRESS_FILE)
 
 def is_mastered(word_progress):
     """Check if a word is mastered based on the mastery rules."""
@@ -437,11 +275,6 @@ def get_progress():
 def reset_progress():
     reset_all_progress()
     return jsonify({'success': True, 'message': 'Progress reset successfully'})
-
-# Initialize database on startup
-if DATABASE_URL:
-    with app.app_context():
-        init_db()
 
 if __name__ == '__main__':
     app.run(debug=True, port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 flask==3.1.2
 gunicorn==23.0.0
-psycopg2-binary==2.9.10


### PR DESCRIPTION
The Render database service has been suspended. The app was crashing on startup because it tried to resolve the dead DB hostname on every request (psycopg2.OperationalError: could not translate host name).

- Remove psycopg2 import, DATABASE_URL config, and all DB functions (get_db_connection, init_db, load_progress_db, save_word_progress, update_user_stats)
- Flatten load_progress/save_progress/reset_all_progress to use the existing JSON file backend unconditionally
- Remove psycopg2-binary from requirements.txt

Progress is now persisted to user_progress.json on the server filesystem.

https://claude.ai/code/session_015dikvENyQLSdGGaK9GJ5Zw