### PR TITLE
Add Strictness setting with Low/High modes and accent-miss feedback

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify, request, render_template
 import json
 import os
 import random
+import unicodedata
 from datetime import datetime
 
 app = Flask(__name__)
@@ -23,10 +24,14 @@ def load_progress_json():
                 'session_count': 1,
                 'last_session': datetime.now().isoformat()
             },
-            'word_progress': {}
+            'word_progress': {},
+            'settings': {'strictness': 'high'}
         }
     with open(PROGRESS_FILE, 'r', encoding='utf-8') as f:
-        return json.load(f)
+        progress = json.load(f)
+    if 'settings' not in progress:
+        progress['settings'] = {'strictness': 'high'}
+    return progress
 
 def save_progress_json(progress):
     with open(PROGRESS_FILE, 'w', encoding='utf-8') as f:
@@ -69,13 +74,29 @@ def normalize_answer(answer):
     """Normalize answer for comparison."""
     return answer.strip().lower()
 
-def check_answer_match(user_answer, correct_answers):
-    """Check if user's answer matches any correct answer."""
+def remove_accents(text):
+    """Remove accent marks from text for loose comparison."""
+    nfkd = unicodedata.normalize('NFKD', text)
+    return ''.join(c for c in nfkd if not unicodedata.combining(c))
+
+def check_answer_match(user_answer, correct_answers, strictness='high'):
+    """Check if user's answer matches any correct answer.
+
+    Returns a dict: {'correct': bool, 'accent_only_miss': bool}.
+    accent_only_miss is True when the answer would be correct if accents are ignored.
+    """
     normalized_user = normalize_answer(user_answer)
     for correct in correct_answers:
         if normalize_answer(correct) == normalized_user:
-            return True
-    return False
+            return {'correct': True, 'accent_only_miss': False}
+
+    if strictness == 'low':
+        user_no_accents = remove_accents(normalized_user)
+        for correct in correct_answers:
+            if remove_accents(normalize_answer(correct)) == user_no_accents:
+                return {'correct': True, 'accent_only_miss': True}
+
+    return {'correct': False, 'accent_only_miss': False}
 
 @app.route('/')
 def index():
@@ -162,8 +183,11 @@ def check_user_answer():
     if not word:
         return jsonify({'error': 'Word not found'}), 404
 
-    # Check the answer
-    is_correct = check_answer_match(user_answer, word['spanish'])
+    # Check the answer using current strictness setting
+    strictness = progress.get('settings', {}).get('strictness', 'high')
+    result = check_answer_match(user_answer, word['spanish'], strictness)
+    is_correct = result['correct']
+    accent_only_miss = result['accent_only_miss']
 
     # Get current word progress
     wp = progress['word_progress'].get(word_id, {
@@ -193,6 +217,7 @@ def check_user_answer():
 
     return jsonify({
         'correct': is_correct,
+        'accent_only_miss': accent_only_miss,
         'valid_answers': word['spanish'],
         'mastered': wp['mastered'],
         'streak': wp['streak']
@@ -270,6 +295,16 @@ def get_progress():
         'session_count': progress['user_stats']['session_count'],
         'last_session': progress['user_stats']['last_session']
     })
+
+@app.route('/api/settings', methods=['GET', 'POST'])
+def handle_settings():
+    progress = load_progress_json()
+    if request.method == 'POST':
+        data = request.get_json()
+        if 'strictness' in data and data['strictness'] in ('low', 'high'):
+            progress['settings']['strictness'] = data['strictness']
+            save_progress_json(progress)
+    return jsonify(progress['settings'])
 
 @app.route('/api/reset', methods=['POST'])
 def reset_progress():

--- a/static/app.js
+++ b/static/app.js
@@ -4,6 +4,7 @@ let isAnswered = false;
 let autoAdvanceTimeout = null;
 let reviewMode = false;
 let reviewedWordIds = [];
+let currentStrictness = 'high';
 
 // DOM Elements
 const englishWordEl = document.getElementById('english-word');
@@ -28,12 +29,16 @@ const activeCountEl = document.getElementById('active-count');
 const reviewModeIndicator = document.getElementById('review-mode-indicator');
 const reviewRemainingEl = document.getElementById('review-remaining');
 const exitReviewBtn = document.getElementById('exit-review-btn');
+const strictnessHighBtn = document.getElementById('btn-strictness-high');
+const strictnessLowBtn = document.getElementById('btn-strictness-low');
+const accentMissNoteEl = document.getElementById('accent-miss-note');
 
 // Initialize
 document.addEventListener('DOMContentLoaded', () => {
     loadNextWord();
     loadProgress();
     loadActiveWordCount();
+    loadSettings();
     setupEventListeners();
 });
 
@@ -45,6 +50,9 @@ function setupEventListeners() {
 
     reviewBtn.addEventListener('click', enterReviewMode);
     exitReviewBtn.addEventListener('click', exitReviewMode);
+
+    strictnessHighBtn.addEventListener('click', () => setStrictness('high'));
+    strictnessLowBtn.addEventListener('click', () => setStrictness('low'));
 
     answerInput.addEventListener('keypress', (e) => {
         if (e.key === 'Enter') {
@@ -95,6 +103,7 @@ async function loadNextWord() {
         isAnswered = false;
         feedbackEl.style.display = 'none';
         feedbackEl.classList.remove('correct', 'incorrect', 'show');
+        accentMissNoteEl.style.display = 'none';
         answerInput.value = '';
         answerInput.disabled = false;
         submitBtn.style.display = 'inline-block';
@@ -187,6 +196,19 @@ async function checkAnswer() {
             }
             feedbackText.textContent = text;
 
+            // Show accent-miss note if the only mistake was a missing accent
+            if (data.accent_only_miss) {
+                const correctForm = data.valid_answers.find(
+                    a => a.toLowerCase().replace(/[^\w\s]/g, '') !== a.toLowerCase() ||
+                         a !== userAnswer
+                ) || data.valid_answers[0];
+                accentMissNoteEl.textContent =
+                    `Heads up: you missed an accent mark (correct: "${correctForm}") — but you still get credit on Low Strictness!`;
+                accentMissNoteEl.style.display = 'block';
+            } else {
+                accentMissNoteEl.style.display = 'none';
+            }
+
             // Show other accepted answers (synonyms) if there are any
             const otherAnswers = data.valid_answers.filter(
                 a => a.toLowerCase() !== userAnswer.toLowerCase()
@@ -198,7 +220,11 @@ async function checkAnswer() {
                     span.textContent = answer;
                     correctAnswersEl.appendChild(span);
                 });
-                // Give more time to read synonyms
+                // Give more time to read synonyms / accent note
+                autoAdvanceTimeout = setTimeout(() => loadNextWord(), 2500);
+            } else if (data.accent_only_miss) {
+                correctAnswersEl.innerHTML = '';
+                // Give time to read the accent miss note
                 autoAdvanceTimeout = setTimeout(() => loadNextWord(), 2500);
             } else {
                 correctAnswersEl.innerHTML = '';
@@ -209,6 +235,7 @@ async function checkAnswer() {
             feedbackEl.classList.add('incorrect');
             feedbackIcon.textContent = '✗';
             feedbackText.textContent = 'Not quite right';
+            accentMissNoteEl.style.display = 'none';
 
             correctAnswersEl.innerHTML = '<strong>Correct answers:</strong>';
             data.valid_answers.forEach(answer => {
@@ -270,6 +297,36 @@ function exitReviewMode() {
     reviewModeIndicator.style.display = 'none';
     loadActiveWordCount();
     loadNextWord();
+}
+
+async function loadSettings() {
+    try {
+        const response = await fetch('/api/settings');
+        const data = await response.json();
+        currentStrictness = data.strictness;
+        updateStrictnessUI();
+    } catch (error) {
+        console.error('Error loading settings:', error);
+    }
+}
+
+function updateStrictnessUI() {
+    strictnessHighBtn.classList.toggle('active', currentStrictness === 'high');
+    strictnessLowBtn.classList.toggle('active', currentStrictness === 'low');
+}
+
+async function setStrictness(value) {
+    try {
+        await fetch('/api/settings', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ strictness: value })
+        });
+        currentStrictness = value;
+        updateStrictnessUI();
+    } catch (error) {
+        console.error('Error saving settings:', error);
+    }
 }
 
 function showCompletion() {

--- a/static/style.css
+++ b/static/style.css
@@ -66,6 +66,42 @@ header h1 {
     opacity: 0.7;
 }
 
+.strictness-setting {
+    margin-top: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 0.85rem;
+}
+
+.strictness-label {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.strictness-option {
+    background: rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    color: rgba(255, 255, 255, 0.85);
+    padding: 4px 14px;
+    border-radius: 15px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.strictness-option:hover {
+    background: rgba(255, 255, 255, 0.35);
+    color: white;
+}
+
+.strictness-option.active {
+    background: rgba(255, 255, 255, 0.92);
+    color: #c0392b;
+    border-color: white;
+}
+
 main {
     padding: 40px 30px;
 }
@@ -312,6 +348,17 @@ main {
     color: #721c24;
 }
 
+.accent-miss-note {
+    background: linear-gradient(145deg, #fff3cd 0%, #ffeeba 100%);
+    color: #856404;
+    border: 1px solid #ffc107;
+    border-radius: 8px;
+    padding: 8px 16px;
+    margin-bottom: 15px;
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
 .correct-answers {
     margin-bottom: 20px;
     color: #555;
@@ -445,6 +492,17 @@ footer {
     }
 
     .stats {
+        font-size: 0.75rem;
+    }
+
+    .strictness-setting {
+        font-size: 0.75rem;
+        gap: 6px;
+        margin-top: 8px;
+    }
+
+    .strictness-option {
+        padding: 3px 10px;
         font-size: 0.75rem;
     }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,11 @@
                     <span class="separator">|</span>
                     <button id="reset-progress-btn" class="reset-link">Reset All Progress</button>
                 </div>
+                <div class="strictness-setting">
+                    <span class="strictness-label">Strictness:</span>
+                    <button class="strictness-option" id="btn-strictness-high" data-value="high">High</button>
+                    <button class="strictness-option" id="btn-strictness-low" data-value="low">Low</button>
+                </div>
             </div>
         </header>
 
@@ -66,6 +71,7 @@
             <div class="feedback" id="feedback" style="display: none;">
                 <div class="feedback-icon" id="feedback-icon"></div>
                 <div class="feedback-text" id="feedback-text"></div>
+                <div class="accent-miss-note" id="accent-miss-note" style="display: none;"></div>
                 <div class="correct-answers" id="correct-answers"></div>
                 <button id="next-btn" class="next-btn">Next Word</button>
             </div>


### PR DESCRIPTION
Introduces a persistent Strictness setting (High/Low) accessible from the header. In Low mode, answers missing only an accent mark (e.g. "a" instead of "á") are counted as correct, and a yellow notice explains to the user that they missed the accent but still earned credit.

- Backend: add `remove_accents()` helper using unicodedata; update `check_answer_match()` to accept `strictness` and return `{'correct', 'accent_only_miss'}`; add `/api/settings` GET/POST endpoint persisted in user_progress.json
- Frontend: strictness toggle buttons in the header; accent-miss note (amber banner) shown inside the correct-feedback area; settings loaded on init and saved on toggle

https://claude.ai/code/session_015dikvENyQLSdGGaK9GJ5Zw