### PR TITLE
Add synonyms and gender variants for words 3501-5000

### DIFF
--- a/words.json
+++ b/words.json
@@ -32158,7 +32158,8 @@
       "id": 3504,
       "english": "imaginary",
       "spanish": [
-        "imaginario"
+        "imaginario",
+        "imaginaria"
       ],
       "rank": 3504,
       "category": "adjective"
@@ -32176,7 +32177,8 @@
       "id": 3506,
       "english": "spread out",
       "spanish": [
-        "disperso"
+        "disperso",
+        "dispersa"
       ],
       "rank": 3506,
       "category": "adjective"
@@ -32185,7 +32187,8 @@
       "id": 3507,
       "english": "naive, ingenuous",
       "spanish": [
-        "ingenuo"
+        "ingenuo",
+        "ingenua"
       ],
       "rank": 3507,
       "category": "adjective"
@@ -32248,7 +32251,8 @@
       "id": 3514,
       "english": "costly, expensive",
       "spanish": [
-        "costoso"
+        "costoso",
+        "costosa"
       ],
       "rank": 3514,
       "category": "adjective"
@@ -32257,7 +32261,8 @@
       "id": 3515,
       "english": "full, overcrowded",
       "spanish": [
-        "repleto"
+        "repleto",
+        "repleta"
       ],
       "rank": 3515,
       "category": "adjective"
@@ -32356,7 +32361,8 @@
       "id": 3526,
       "english": "amazing",
       "spanish": [
-        "asombroso"
+        "asombroso",
+        "asombrosa"
       ],
       "rank": 3526,
       "category": "adjective"
@@ -32437,7 +32443,8 @@
       "id": 3535,
       "english": "appropriate, fit, able",
       "spanish": [
-        "apto"
+        "apto",
+        "apta"
       ],
       "rank": 3535,
       "category": "adjective"
@@ -32446,7 +32453,8 @@
       "id": 3536,
       "english": "uncertain",
       "spanish": [
-        "incierto"
+        "incierto",
+        "incierta"
       ],
       "rank": 3536,
       "category": "adjective"
@@ -32455,7 +32463,8 @@
       "id": 3537,
       "english": "thick",
       "spanish": [
-        "espeso"
+        "espeso",
+        "espesa"
       ],
       "rank": 3537,
       "category": "adjective"
@@ -32545,7 +32554,8 @@
       "id": 3547,
       "english": "passionate",
       "spanish": [
-        "apasionado"
+        "apasionado",
+        "apasionada"
       ],
       "rank": 3547,
       "category": "adjective"
@@ -32563,7 +32573,8 @@
       "id": 3549,
       "english": "abstract",
       "spanish": [
-        "abstracto"
+        "abstracto",
+        "abstracta"
       ],
       "rank": 3549,
       "category": "adjective"
@@ -32581,7 +32592,8 @@
       "id": 3551,
       "english": "creative",
       "spanish": [
-        "creativo"
+        "creativo",
+        "creativa"
       ],
       "rank": 3551,
       "category": "adjective"
@@ -32590,7 +32602,8 @@
       "id": 3552,
       "english": "authoritarian",
       "spanish": [
-        "autoritario"
+        "autoritario",
+        "autoritaria"
       ],
       "rank": 3552,
       "category": "adjective"
@@ -32617,7 +32630,8 @@
       "id": 3555,
       "english": "underground",
       "spanish": [
-        "subterráneo"
+        "subterráneo",
+        "subterránea"
       ],
       "rank": 3555,
       "category": "adjective"
@@ -32725,7 +32739,8 @@
       "id": 3567,
       "english": "systematic",
       "spanish": [
-        "sistemático"
+        "sistemático",
+        "sistemática"
       ],
       "rank": 3567,
       "category": "adjective"
@@ -32752,7 +32767,8 @@
       "id": 3570,
       "english": "utmost, highest",
       "spanish": [
-        "sumo"
+        "sumo",
+        "suma"
       ],
       "rank": 3570,
       "category": "adjective"
@@ -32833,7 +32849,8 @@
       "id": 3579,
       "english": "privileged",
       "spanish": [
-        "privilegiado"
+        "privilegiado",
+        "privilegiada"
       ],
       "rank": 3579,
       "category": "adjective"
@@ -32932,7 +32949,8 @@
       "id": 3590,
       "english": "lukewarm",
       "spanish": [
-        "tibio"
+        "tibio",
+        "tibia"
       ],
       "rank": 3590,
       "category": "adjective"
@@ -32950,7 +32968,8 @@
       "id": 3592,
       "english": "suspicious",
       "spanish": [
-        "sospechoso"
+        "sospechoso",
+        "sospechosa"
       ],
       "rank": 3592,
       "category": "adjective"
@@ -32986,7 +33005,8 @@
       "id": 3596,
       "english": "fabulous, fantastic",
       "spanish": [
-        "fabuloso"
+        "fabuloso",
+        "fabulosa"
       ],
       "rank": 3596,
       "category": "adjective"
@@ -33067,7 +33087,8 @@
       "id": 3605,
       "english": "heavy",
       "spanish": [
-        "denso"
+        "denso",
+        "densa"
       ],
       "rank": 3605,
       "category": "adjective"
@@ -33121,7 +33142,8 @@
       "id": 3611,
       "english": "agricultural, farming",
       "spanish": [
-        "agrícola"
+        "agrícola",
+        "agrícolo"
       ],
       "rank": 3611,
       "category": "adjective"
@@ -33310,7 +33332,8 @@
       "id": 3632,
       "english": "smooth, flat, straight",
       "spanish": [
-        "liso"
+        "liso",
+        "lisa"
       ],
       "rank": 3632,
       "category": "adjective"
@@ -33319,7 +33342,8 @@
       "id": 3633,
       "english": "scared, frightened",
       "spanish": [
-        "asustado"
+        "asustado",
+        "asustada"
       ],
       "rank": 3633,
       "category": "adjective"
@@ -33346,7 +33370,8 @@
       "id": 3636,
       "english": "appropriate, suitable",
       "spanish": [
-        "propicio"
+        "propicio",
+        "propicia"
       ],
       "rank": 3636,
       "category": "adjective"
@@ -33418,7 +33443,8 @@
       "id": 3644,
       "english": "aforementioned, said",
       "spanish": [
-        "dicho"
+        "dicho",
+        "dicha"
       ],
       "rank": 3644,
       "category": "adjective"
@@ -33427,7 +33453,8 @@
       "id": 3645,
       "english": "ambiguous",
       "spanish": [
-        "ambiguo"
+        "ambiguo",
+        "ambigua"
       ],
       "rank": 3645,
       "category": "adjective"
@@ -33499,7 +33526,8 @@
       "id": 3653,
       "english": "respectful",
       "spanish": [
-        "respetuoso"
+        "respetuoso",
+        "respetuosa"
       ],
       "rank": 3653,
       "category": "adjective"
@@ -33508,7 +33536,8 @@
       "id": 3654,
       "english": "African",
       "spanish": [
-        "africano"
+        "africano",
+        "africana"
       ],
       "rank": 3654,
       "category": "adjective"
@@ -33679,7 +33708,8 @@
       "id": 3673,
       "english": "thin, frail",
       "spanish": [
-        "flaco"
+        "flaco",
+        "flaca"
       ],
       "rank": 3673,
       "category": "adjective"
@@ -33688,7 +33718,8 @@
       "id": 3674,
       "english": "biological",
       "spanish": [
-        "biológico"
+        "biológico",
+        "biológica"
       ],
       "rank": 3674,
       "category": "adjective"
@@ -33751,7 +33782,8 @@
       "id": 3681,
       "english": "diplomatic",
       "spanish": [
-        "diplomático"
+        "diplomático",
+        "diplomática"
       ],
       "rank": 3681,
       "category": "adjective"
@@ -33787,7 +33819,8 @@
       "id": 3685,
       "english": "progressive",
       "spanish": [
-        "progresivo"
+        "progresivo",
+        "progresiva"
       ],
       "rank": 3685,
       "category": "adjective"
@@ -33823,7 +33856,8 @@
       "id": 3689,
       "english": "glorious",
       "spanish": [
-        "glorioso"
+        "glorioso",
+        "gloriosa"
       ],
       "rank": 3689,
       "category": "adjective"
@@ -33841,7 +33875,8 @@
       "id": 3691,
       "english": "Turkish",
       "spanish": [
-        "turco"
+        "turco",
+        "turca"
       ],
       "rank": 3691,
       "category": "adjective"
@@ -33877,7 +33912,8 @@
       "id": 3695,
       "english": "populated metros",
       "spanish": [
-        "poblado"
+        "poblado",
+        "poblada"
       ],
       "rank": 3695,
       "category": "adjective"
@@ -33895,7 +33931,8 @@
       "id": 3697,
       "english": "printed",
       "spanish": [
-        "impreso"
+        "impreso",
+        "impresa"
       ],
       "rank": 3697,
       "category": "adjective"
@@ -33949,7 +33986,8 @@
       "id": 3703,
       "english": "inverse, opposite",
       "spanish": [
-        "inverso"
+        "inverso",
+        "inversa"
       ],
       "rank": 3703,
       "category": "adjective"
@@ -34066,7 +34104,8 @@
       "id": 3716,
       "english": "organic",
       "spanish": [
-        "orgánico"
+        "orgánico",
+        "orgánica"
       ],
       "rank": 3716,
       "category": "adjective"
@@ -34120,7 +34159,8 @@
       "id": 3722,
       "english": "brown, dark, dim",
       "spanish": [
-        "pardo"
+        "pardo",
+        "parda"
       ],
       "rank": 3722,
       "category": "adjective"
@@ -34165,7 +34205,8 @@
       "id": 3727,
       "english": "spread, hung",
       "spanish": [
-        "tendido"
+        "tendido",
+        "tendida"
       ],
       "rank": 3727,
       "category": "adjective"
@@ -34255,7 +34296,8 @@
       "id": 3737,
       "english": "painful",
       "spanish": [
-        "penoso"
+        "penoso",
+        "penosa"
       ],
       "rank": 3737,
       "category": "adjective"
@@ -34318,7 +34360,8 @@
       "id": 3744,
       "english": "preferred, favorite",
       "spanish": [
-        "preferido"
+        "preferido",
+        "preferida"
       ],
       "rank": 3744,
       "category": "adjective"
@@ -34408,7 +34451,9 @@
       "id": 3754,
       "english": "to return, give back",
       "spanish": [
-        "retornar"
+        "retornar",
+        "regresar",
+        "volver"
       ],
       "rank": 3754,
       "category": "verb"
@@ -34426,7 +34471,8 @@
       "id": 3756,
       "english": "imprisoned, confined",
       "spanish": [
-        "preso"
+        "preso",
+        "presa"
       ],
       "rank": 3756,
       "category": "adjective"
@@ -34624,7 +34670,8 @@
       "id": 3778,
       "english": "mass, massive",
       "spanish": [
-        "masivo"
+        "masivo",
+        "masiva"
       ],
       "rank": 3778,
       "category": "adjective"
@@ -34660,7 +34707,8 @@
       "id": 3782,
       "english": "deserted",
       "spanish": [
-        "desierto"
+        "desierto",
+        "desierta"
       ],
       "rank": 3782,
       "category": "adjective"
@@ -34768,7 +34816,8 @@
       "id": 3794,
       "english": "educational",
       "spanish": [
-        "educativo"
+        "educativo",
+        "educativa"
       ],
       "rank": 3794,
       "category": "adjective"
@@ -34876,7 +34925,8 @@
       "id": 3806,
       "english": "tight, jammed",
       "spanish": [
-        "apretado"
+        "apretado",
+        "apretada"
       ],
       "rank": 3806,
       "category": "adjective"
@@ -34939,7 +34989,8 @@
       "id": 3813,
       "english": "missing",
       "spanish": [
-        "desaparecido"
+        "desaparecido",
+        "desaparecida"
       ],
       "rank": 3813,
       "category": "adjective"
@@ -34975,7 +35026,8 @@
       "id": 3817,
       "english": "dreadful, awful",
       "spanish": [
-        "pésimo"
+        "pésimo",
+        "pésima"
       ],
       "rank": 3817,
       "category": "adjective"
@@ -35227,7 +35279,8 @@
       "id": 3845,
       "english": "selfish",
       "spanish": [
-        "egoísta"
+        "egoísta",
+        "egoísto"
       ],
       "rank": 3845,
       "category": "adjective"
@@ -35245,7 +35298,8 @@
       "id": 3847,
       "english": "exotic",
       "spanish": [
-        "exótico"
+        "exótico",
+        "exótica"
       ],
       "rank": 3847,
       "category": "adjective"
@@ -35308,7 +35362,8 @@
       "id": 3854,
       "english": "rough, coarse, harsh",
       "spanish": [
-        "áspero"
+        "áspero",
+        "áspera"
       ],
       "rank": 3854,
       "category": "adjective"
@@ -35416,7 +35471,8 @@
       "id": 3866,
       "english": "luxurious",
       "spanish": [
-        "lujoso"
+        "lujoso",
+        "lujosa"
       ],
       "rank": 3866,
       "category": "adjective"
@@ -35524,7 +35580,8 @@
       "id": 3878,
       "english": "open, frank, outspoken",
       "spanish": [
-        "franco"
+        "franco",
+        "franca"
       ],
       "rank": 3878,
       "category": "adjective"
@@ -35533,7 +35590,8 @@
       "id": 3879,
       "english": "unpublished",
       "spanish": [
-        "inédito"
+        "inédito",
+        "inédita"
       ],
       "rank": 3879,
       "category": "adjective"
@@ -35632,7 +35690,8 @@
       "id": 3890,
       "english": "linguistic",
       "spanish": [
-        "lingüístico"
+        "lingüístico",
+        "lingüística"
       ],
       "rank": 3890,
       "category": "adjective"
@@ -35650,7 +35709,8 @@
       "id": 3892,
       "english": "Mexican",
       "spanish": [
-        "mexicano"
+        "mexicano",
+        "mexicana"
       ],
       "rank": 3892,
       "category": "adjective"
@@ -35686,7 +35746,8 @@
       "id": 3896,
       "english": "authorized",
       "spanish": [
-        "autorizado"
+        "autorizado",
+        "autorizada"
       ],
       "rank": 3896,
       "category": "adjective"
@@ -35767,7 +35828,8 @@
       "id": 3905,
       "english": "Cuban",
       "spanish": [
-        "cubano"
+        "cubano",
+        "cubana"
       ],
       "rank": 3905,
       "category": "adjective"
@@ -35821,7 +35883,8 @@
       "id": 3911,
       "english": "bloody",
       "spanish": [
-        "sangriento"
+        "sangriento",
+        "sangrienta"
       ],
       "rank": 3911,
       "category": "adjective"
@@ -35830,7 +35893,8 @@
       "id": 3912,
       "english": "mathematical",
       "spanish": [
-        "matemático"
+        "matemático",
+        "matemática"
       ],
       "rank": 3912,
       "category": "adjective"
@@ -35929,7 +35993,8 @@
       "id": 3923,
       "english": "static, motionless",
       "spanish": [
-        "estático"
+        "estático",
+        "estática"
       ],
       "rank": 3923,
       "category": "adjective"
@@ -35992,7 +36057,8 @@
       "id": 3930,
       "english": "representative",
       "spanish": [
-        "representativo"
+        "representativo",
+        "representativa"
       ],
       "rank": 3930,
       "category": "adjective"
@@ -36073,7 +36139,8 @@
       "id": 3939,
       "english": "furious",
       "spanish": [
-        "furioso"
+        "furioso",
+        "furiosa"
       ],
       "rank": 3939,
       "category": "adjective"
@@ -36082,7 +36149,8 @@
       "id": 3940,
       "english": "studious",
       "spanish": [
-        "estudioso"
+        "estudioso",
+        "estudiosa"
       ],
       "rank": 3940,
       "category": "adjective"
@@ -36136,7 +36204,8 @@
       "id": 3946,
       "english": "Basque",
       "spanish": [
-        "vasco"
+        "vasco",
+        "vasca"
       ],
       "rank": 3946,
       "category": "adjective"
@@ -36154,7 +36223,8 @@
       "id": 3948,
       "english": "additional",
       "spanish": [
-        "complementario"
+        "complementario",
+        "complementaria"
       ],
       "rank": 3948,
       "category": "adjective"
@@ -36181,7 +36251,8 @@
       "id": 3951,
       "english": "unusual, uncommon",
       "spanish": [
-        "insólito"
+        "insólito",
+        "insólita"
       ],
       "rank": 3951,
       "category": "adjective"
@@ -36190,7 +36261,8 @@
       "id": 3952,
       "english": "fearful",
       "spanish": [
-        "temeroso"
+        "temeroso",
+        "temerosa"
       ],
       "rank": 3952,
       "category": "adjective"
@@ -36226,7 +36298,8 @@
       "id": 3956,
       "english": "dedicated, consecrated",
       "spanish": [
-        "consagrado"
+        "consagrado",
+        "consagrada"
       ],
       "rank": 3956,
       "category": "adjective"
@@ -36244,7 +36317,8 @@
       "id": 3958,
       "english": "awake",
       "spanish": [
-        "despierto"
+        "despierto",
+        "despierta"
       ],
       "rank": 3958,
       "category": "adjective"
@@ -36343,7 +36417,8 @@
       "id": 3969,
       "english": "pregnant",
       "spanish": [
-        "embarazada"
+        "embarazada",
+        "embarazado"
       ],
       "rank": 3969,
       "category": "adjective"
@@ -36361,7 +36436,8 @@
       "id": 3971,
       "english": "Latin American",
       "spanish": [
-        "latinoamericano"
+        "latinoamericano",
+        "latinoamericana"
       ],
       "rank": 3971,
       "category": "adjective"
@@ -36370,7 +36446,8 @@
       "id": 3972,
       "english": "technological",
       "spanish": [
-        "tecnológico"
+        "tecnológico",
+        "tecnológica"
       ],
       "rank": 3972,
       "category": "adjective"
@@ -36622,7 +36699,8 @@
       "id": 4000,
       "english": "civilized",
       "spanish": [
-        "civilizado"
+        "civilizado",
+        "civilizada"
       ],
       "rank": 4000,
       "category": "adjective"
@@ -36757,7 +36835,8 @@
       "id": 4015,
       "english": "arbitrary",
       "spanish": [
-        "arbitrario"
+        "arbitrario",
+        "arbitraria"
       ],
       "rank": 4015,
       "category": "adjective"
@@ -36847,7 +36926,8 @@
       "id": 4025,
       "english": "diminutive, tiny, minute",
       "spanish": [
-        "diminuto"
+        "diminuto",
+        "diminuta"
       ],
       "rank": 4025,
       "category": "adjective"
@@ -36910,7 +36990,8 @@
       "id": 4032,
       "english": "journalistic",
       "spanish": [
-        "periodístico"
+        "periodístico",
+        "periodística"
       ],
       "rank": 4032,
       "category": "adjective"
@@ -36919,7 +37000,8 @@
       "id": 4033,
       "english": "affectionate",
       "spanish": [
-        "cariñoso"
+        "cariñoso",
+        "cariñosa"
       ],
       "rank": 4033,
       "category": "adjective"
@@ -36982,7 +37064,8 @@
       "id": 4040,
       "english": "correct, accurate",
       "spanish": [
-        "acertado"
+        "acertado",
+        "acertada"
       ],
       "rank": 4040,
       "category": "adjective"
@@ -37027,7 +37110,8 @@
       "id": 4045,
       "english": "agitated, irritated",
       "spanish": [
-        "agitado"
+        "agitado",
+        "agitada"
       ],
       "rank": 4045,
       "category": "adjective"
@@ -37036,7 +37120,8 @@
       "id": 4046,
       "english": "precarious",
       "spanish": [
-        "precario"
+        "precario",
+        "precaria"
       ],
       "rank": 4046,
       "category": "adjective"
@@ -37045,7 +37130,8 @@
       "id": 4047,
       "english": "health, sanitary, clean",
       "spanish": [
-        "sanitario"
+        "sanitario",
+        "sanitaria"
       ],
       "rank": 4047,
       "category": "adjective"
@@ -37063,7 +37149,8 @@
       "id": 4049,
       "english": "careful, cautious",
       "spanish": [
-        "cuidadoso"
+        "cuidadoso",
+        "cuidadosa"
       ],
       "rank": 4049,
       "category": "adjective"
@@ -37117,7 +37204,8 @@
       "id": 4055,
       "english": "buried, sunken",
       "spanish": [
-        "hundido"
+        "hundido",
+        "hundida"
       ],
       "rank": 4055,
       "category": "adjective"
@@ -37198,7 +37286,8 @@
       "id": 4064,
       "english": "dynamic",
       "spanish": [
-        "dinámico"
+        "dinámico",
+        "dinámica"
       ],
       "rank": 4064,
       "category": "adjective"
@@ -37216,7 +37305,8 @@
       "id": 4066,
       "english": "serene, calm",
       "spanish": [
-        "sereno"
+        "sereno",
+        "serena"
       ],
       "rank": 4066,
       "category": "adjective"
@@ -37225,7 +37315,8 @@
       "id": 4067,
       "english": "retired, remote, secluded",
       "spanish": [
-        "retirado"
+        "retirado",
+        "retirada"
       ],
       "rank": 4067,
       "category": "adjective"
@@ -37261,7 +37352,8 @@
       "id": 4071,
       "english": "refined",
       "spanish": [
-        "refinado"
+        "refinado",
+        "refinada"
       ],
       "rank": 4071,
       "category": "adjective"
@@ -37414,7 +37506,8 @@
       "id": 4088,
       "english": "damned, wretched",
       "spanish": [
-        "maldito"
+        "maldito",
+        "maldita"
       ],
       "rank": 4088,
       "category": "adjective"
@@ -37486,7 +37579,8 @@
       "id": 4096,
       "english": "crude, rude, crass",
       "spanish": [
-        "grosero"
+        "grosero",
+        "grosera"
       ],
       "rank": 4096,
       "category": "adjective"
@@ -37657,7 +37751,8 @@
       "id": 4115,
       "english": "disguised",
       "spanish": [
-        "disfrazado"
+        "disfrazado",
+        "disfrazada"
       ],
       "rank": 4115,
       "category": "adjective"
@@ -37702,7 +37797,8 @@
       "id": 4120,
       "english": "behind, slow",
       "spanish": [
-        "atrasado"
+        "atrasado",
+        "atrasada"
       ],
       "rank": 4120,
       "category": "adjective"
@@ -37729,7 +37825,8 @@
       "id": 4123,
       "english": "grateful, thankful",
       "spanish": [
-        "agradecido"
+        "agradecido",
+        "agradecida"
       ],
       "rank": 4123,
       "category": "adjective"
@@ -37756,7 +37853,8 @@
       "id": 4126,
       "english": "conditioned",
       "spanish": [
-        "condicionado"
+        "condicionado",
+        "condicionada"
       ],
       "rank": 4126,
       "category": "adjective"
@@ -37783,7 +37881,8 @@
       "id": 4129,
       "english": "optimum",
       "spanish": [
-        "óptimo"
+        "óptimo",
+        "óptima"
       ],
       "rank": 4129,
       "category": "adjective"
@@ -37792,7 +37891,8 @@
       "id": 4130,
       "english": "sudden",
       "spanish": [
-        "súbito"
+        "súbito",
+        "súbita"
       ],
       "rank": 4130,
       "category": "adjective"
@@ -37882,7 +37982,8 @@
       "id": 4140,
       "english": "handsome, beautiful",
       "spanish": [
-        "guapo"
+        "guapo",
+        "guapa"
       ],
       "rank": 4140,
       "category": "adjective"
@@ -37918,7 +38019,8 @@
       "id": 4144,
       "english": "engrossed, immersed",
       "spanish": [
-        "inmerso"
+        "inmerso",
+        "inmersa"
       ],
       "rank": 4144,
       "category": "adjective"
@@ -38026,7 +38128,8 @@
       "id": 4156,
       "english": "genetic",
       "spanish": [
-        "genético"
+        "genético",
+        "genética"
       ],
       "rank": 4156,
       "category": "adjective"
@@ -38080,7 +38183,8 @@
       "id": 4162,
       "english": "compact",
       "spanish": [
-        "compacto"
+        "compacto",
+        "compacta"
       ],
       "rank": 4162,
       "category": "adjective"
@@ -38161,7 +38265,8 @@
       "id": 4171,
       "english": "strategic",
       "spanish": [
-        "estratégico"
+        "estratégico",
+        "estratégica"
       ],
       "rank": 4171,
       "category": "adjective"
@@ -38179,7 +38284,8 @@
       "id": 4173,
       "english": "ethical enfermedad",
       "spanish": [
-        "ético"
+        "ético",
+        "ética"
       ],
       "rank": 4173,
       "category": "adjective"
@@ -38197,7 +38303,8 @@
       "id": 4175,
       "english": "aware of",
       "spanish": [
-        "enterado"
+        "enterado",
+        "enterada"
       ],
       "rank": 4175,
       "category": "adjective"
@@ -38242,7 +38349,8 @@
       "id": 4180,
       "english": "alternating, alternative",
       "spanish": [
-        "alternativo"
+        "alternativo",
+        "alternativa"
       ],
       "rank": 4180,
       "category": "adjective"
@@ -38251,7 +38359,8 @@
       "id": 4181,
       "english": "expressive",
       "spanish": [
-        "expresivo"
+        "expresivo",
+        "expresiva"
       ],
       "rank": 4181,
       "category": "adjective"
@@ -38350,7 +38459,8 @@
       "id": 4192,
       "english": "continual, perpetual",
       "spanish": [
-        "perpetuo"
+        "perpetuo",
+        "perpetua"
       ],
       "rank": 4192,
       "category": "adjective"
@@ -38494,7 +38604,8 @@
       "id": 4208,
       "english": "buried",
       "spanish": [
-        "enterrado"
+        "enterrado",
+        "enterrada"
       ],
       "rank": 4208,
       "category": "adjective"
@@ -38521,7 +38632,8 @@
       "id": 4211,
       "english": "jealous",
       "spanish": [
-        "celoso"
+        "celoso",
+        "celosa"
       ],
       "rank": 4211,
       "category": "adjective"
@@ -38638,7 +38750,8 @@
       "id": 4224,
       "english": "reflected",
       "spanish": [
-        "reflejado"
+        "reflejado",
+        "reflejada"
       ],
       "rank": 4224,
       "category": "adjective"
@@ -38674,7 +38787,8 @@
       "id": 4228,
       "english": "detailed, thorough",
       "spanish": [
-        "detallado"
+        "detallado",
+        "detallada"
       ],
       "rank": 4228,
       "category": "adjective"
@@ -38728,7 +38842,8 @@
       "id": 4234,
       "english": "trapped",
       "spanish": [
-        "atrapado"
+        "atrapado",
+        "atrapada"
       ],
       "rank": 4234,
       "category": "adjective"
@@ -38800,7 +38915,8 @@
       "id": 4242,
       "english": "light, frivolous",
       "spanish": [
-        "liviano"
+        "liviano",
+        "liviana"
       ],
       "rank": 4242,
       "category": "adjective"
@@ -38809,7 +38925,8 @@
       "id": 4243,
       "english": "enthused, excited",
       "spanish": [
-        "entusiasmado"
+        "entusiasmado",
+        "entusiasmada"
       ],
       "rank": 4243,
       "category": "adjective"
@@ -38899,7 +39016,9 @@
       "id": 4253,
       "english": "computer",
       "spanish": [
-        "computadora"
+        "computadora",
+        "ordenador",
+        "computador"
       ],
       "rank": 4253,
       "category": "noun"
@@ -38971,7 +39090,8 @@
       "id": 4261,
       "english": "noisy",
       "spanish": [
-        "ruidoso"
+        "ruidoso",
+        "ruidosa"
       ],
       "rank": 4261,
       "category": "adjective"
@@ -39043,7 +39163,8 @@
       "id": 4269,
       "english": "undercover, clandestine",
       "spanish": [
-        "clandestino"
+        "clandestino",
+        "clandestina"
       ],
       "rank": 4269,
       "category": "adjective"
@@ -39052,7 +39173,8 @@
       "id": 4270,
       "english": "defensive",
       "spanish": [
-        "defensivo"
+        "defensivo",
+        "defensiva"
       ],
       "rank": 4270,
       "category": "adjective"
@@ -39115,7 +39237,8 @@
       "id": 4277,
       "english": "mixed, co-ed",
       "spanish": [
-        "mixto"
+        "mixto",
+        "mixta"
       ],
       "rank": 4277,
       "category": "adjective"
@@ -39259,7 +39382,8 @@
       "id": 4293,
       "english": "picturesque",
       "spanish": [
-        "pintoresco"
+        "pintoresco",
+        "pintoresca"
       ],
       "rank": 4293,
       "category": "adjective"
@@ -39295,7 +39419,8 @@
       "id": 4297,
       "english": "advertising",
       "spanish": [
-        "publicitario"
+        "publicitario",
+        "publicitaria"
       ],
       "rank": 4297,
       "category": "adjective"
@@ -39475,7 +39600,8 @@
       "id": 4317,
       "english": "passive",
       "spanish": [
-        "pasivo"
+        "pasivo",
+        "pasiva"
       ],
       "rank": 4317,
       "category": "adjective"
@@ -39520,7 +39646,8 @@
       "id": 4322,
       "english": "striking",
       "spanish": [
-        "llamativo"
+        "llamativo",
+        "llamativa"
       ],
       "rank": 4322,
       "category": "adjective"
@@ -39601,7 +39728,8 @@
       "id": 4331,
       "english": "justifiable, justified",
       "spanish": [
-        "justificado"
+        "justificado",
+        "justificada"
       ],
       "rank": 4331,
       "category": "adjective"
@@ -39619,7 +39747,8 @@
       "id": 4333,
       "english": "photographic",
       "spanish": [
-        "fotográfico"
+        "fotográfico",
+        "fotográfica"
       ],
       "rank": 4333,
       "category": "adjective"
@@ -39637,7 +39766,8 @@
       "id": 4335,
       "english": "messy, confused",
       "spanish": [
-        "desordenado"
+        "desordenado",
+        "desordenada"
       ],
       "rank": 4335,
       "category": "adjective"
@@ -39646,7 +39776,8 @@
       "id": 4336,
       "english": "graphic, explicit",
       "spanish": [
-        "gráfico"
+        "gráfico",
+        "gráfica"
       ],
       "rank": 4336,
       "category": "adjective"
@@ -39664,7 +39795,8 @@
       "id": 4338,
       "english": "confused, messed up",
       "spanish": [
-        "revuelto"
+        "revuelto",
+        "revuelta"
       ],
       "rank": 4338,
       "category": "adjective"
@@ -39727,7 +39859,8 @@
       "id": 4345,
       "english": "express, explicit",
       "spanish": [
-        "expreso"
+        "expreso",
+        "expresa"
       ],
       "rank": 4345,
       "category": "adjective"
@@ -39763,7 +39896,8 @@
       "id": 4349,
       "english": "erotic",
       "spanish": [
-        "erótico"
+        "erótico",
+        "erótica"
       ],
       "rank": 4349,
       "category": "adjective"
@@ -39772,7 +39906,8 @@
       "id": 4350,
       "english": "threatened",
       "spanish": [
-        "amenazado"
+        "amenazado",
+        "amenazada"
       ],
       "rank": 4350,
       "category": "adjective"
@@ -39853,7 +39988,8 @@
       "id": 4359,
       "english": "Peruvian",
       "spanish": [
-        "peruano"
+        "peruano",
+        "peruana"
       ],
       "rank": 4359,
       "category": "adjective"
@@ -39880,7 +40016,8 @@
       "id": 4362,
       "english": "dull, opaque, heavy",
       "spanish": [
-        "opaco"
+        "opaco",
+        "opaca"
       ],
       "rank": 4362,
       "category": "adjective"
@@ -39961,7 +40098,8 @@
       "id": 4371,
       "english": "ephemeral, short-lived",
       "spanish": [
-        "efímero"
+        "efímero",
+        "efímera"
       ],
       "rank": 4371,
       "category": "adjective"
@@ -39988,7 +40126,8 @@
       "id": 4374,
       "english": "reversed, inverted",
       "spanish": [
-        "invertido"
+        "invertido",
+        "invertida"
       ],
       "rank": 4374,
       "category": "adjective"
@@ -40051,7 +40190,8 @@
       "id": 4381,
       "english": "transitory",
       "spanish": [
-        "transitorio"
+        "transitorio",
+        "transitoria"
       ],
       "rank": 4381,
       "category": "adjective"
@@ -40069,7 +40209,8 @@
       "id": 4383,
       "english": "wet",
       "spanish": [
-        "mojado"
+        "mojado",
+        "mojada"
       ],
       "rank": 4383,
       "category": "adjective"
@@ -40078,7 +40219,8 @@
       "id": 4384,
       "english": "barefoot",
       "spanish": [
-        "descalzo"
+        "descalzo",
+        "descalza"
       ],
       "rank": 4384,
       "category": "adjective"
@@ -40087,7 +40229,8 @@
       "id": 4385,
       "english": "positioned, guided",
       "spanish": [
-        "orientado"
+        "orientado",
+        "orientada"
       ],
       "rank": 4385,
       "category": "adjective"
@@ -40141,7 +40284,8 @@
       "id": 4391,
       "english": "Brazilian",
       "spanish": [
-        "brasileño"
+        "brasileño",
+        "brasileña"
       ],
       "rank": 4391,
       "category": "adjective"
@@ -40168,7 +40312,8 @@
       "id": 4394,
       "english": "meticulous, thorough",
       "spanish": [
-        "minucioso"
+        "minucioso",
+        "minuciosa"
       ],
       "rank": 4394,
       "category": "adjective"
@@ -40177,7 +40322,8 @@
       "id": 4395,
       "english": "rustic, rural",
       "spanish": [
-        "rústico"
+        "rústico",
+        "rústica"
       ],
       "rank": 4395,
       "category": "adjective"
@@ -40267,7 +40413,8 @@
       "id": 4405,
       "english": "turned off",
       "spanish": [
-        "apagado"
+        "apagado",
+        "apagada"
       ],
       "rank": 4405,
       "category": "adjective"
@@ -40366,7 +40513,8 @@
       "id": 4416,
       "english": "of the community",
       "spanish": [
-        "comunitario"
+        "comunitario",
+        "comunitaria"
       ],
       "rank": 4416,
       "category": "adjective"
@@ -40375,7 +40523,8 @@
       "id": 4417,
       "english": "explicit",
       "spanish": [
-        "explícito"
+        "explícito",
+        "explícita"
       ],
       "rank": 4417,
       "category": "adjective"
@@ -40474,7 +40623,8 @@
       "id": 4428,
       "english": "honest, respectable",
       "spanish": [
-        "honrado"
+        "honrado",
+        "honrada"
       ],
       "rank": 4428,
       "category": "adjective"
@@ -40483,7 +40633,8 @@
       "id": 4429,
       "english": "fast, quick",
       "spanish": [
-        "veloz"
+        "veloz",
+        "rápido"
       ],
       "rank": 4429,
       "category": "adjective"
@@ -40519,7 +40670,8 @@
       "id": 4433,
       "english": "monotonous",
       "spanish": [
-        "monótono"
+        "monótono",
+        "monótona"
       ],
       "rank": 4433,
       "category": "adjective"
@@ -40537,7 +40689,8 @@
       "id": 4435,
       "english": "to scare, frighten",
       "spanish": [
-        "espantar"
+        "espantar",
+        "asustar"
       ],
       "rank": 4435,
       "category": "verb"
@@ -40546,7 +40699,8 @@
       "id": 4436,
       "english": "unforeseen, unexpected",
       "spanish": [
-        "imprevisto"
+        "imprevisto",
+        "imprevista"
       ],
       "rank": 4436,
       "category": "adjective"
@@ -40564,7 +40718,8 @@
       "id": 4438,
       "english": "Soviet",
       "spanish": [
-        "soviético"
+        "soviético",
+        "soviética"
       ],
       "rank": 4438,
       "category": "adjective"
@@ -40618,7 +40773,8 @@
       "id": 4444,
       "english": "perverse, wicked",
       "spanish": [
-        "perverso"
+        "perverso",
+        "perversa"
       ],
       "rank": 4444,
       "category": "adjective"
@@ -40717,7 +40873,8 @@
       "id": 4455,
       "english": "shady, dark, dismal",
       "spanish": [
-        "sombrío"
+        "sombrío",
+        "sombría"
       ],
       "rank": 4455,
       "category": "adjective"
@@ -40771,7 +40928,8 @@
       "id": 4461,
       "english": "pink, rosy",
       "spanish": [
-        "rosado"
+        "rosado",
+        "rosada"
       ],
       "rank": 4461,
       "category": "adjective"
@@ -40780,7 +40938,8 @@
       "id": 4462,
       "english": "friendly",
       "spanish": [
-        "amistoso"
+        "amistoso",
+        "amistosa"
       ],
       "rank": 4462,
       "category": "adjective"
@@ -40852,7 +41011,8 @@
       "id": 4470,
       "english": "poor, needy",
       "spanish": [
-        "necesitado"
+        "necesitado",
+        "necesitada"
       ],
       "rank": 4470,
       "category": "adjective"
@@ -40861,7 +41021,8 @@
       "id": 4471,
       "english": "vague, indefinite",
       "spanish": [
-        "indefinido"
+        "indefinido",
+        "indefinida"
       ],
       "rank": 4471,
       "category": "adjective"
@@ -40870,7 +41031,8 @@
       "id": 4472,
       "english": "united, jointly shared",
       "spanish": [
-        "solidario"
+        "solidario",
+        "solidaria"
       ],
       "rank": 4472,
       "category": "adjective"
@@ -40879,7 +41041,8 @@
       "id": 4473,
       "english": "paralyzed",
       "spanish": [
-        "paralizado"
+        "paralizado",
+        "paralizada"
       ],
       "rank": 4473,
       "category": "adjective"
@@ -40996,7 +41159,8 @@
       "id": 4486,
       "english": "republican",
       "spanish": [
-        "republicano"
+        "republicano",
+        "republicana"
       ],
       "rank": 4486,
       "category": "adjective"
@@ -41005,7 +41169,8 @@
       "id": 4487,
       "english": "destroyed",
       "spanish": [
-        "destruido"
+        "destruido",
+        "destruida"
       ],
       "rank": 4487,
       "category": "adjective"
@@ -41041,7 +41206,8 @@
       "id": 4491,
       "english": "magnificent, grandiose",
       "spanish": [
-        "grandioso"
+        "grandioso",
+        "grandiosa"
       ],
       "rank": 4491,
       "category": "adjective"
@@ -41095,7 +41261,8 @@
       "id": 4497,
       "english": "fortunate, happy",
       "spanish": [
-        "dichoso"
+        "dichoso",
+        "dichosa"
       ],
       "rank": 4497,
       "category": "adjective"
@@ -41113,7 +41280,8 @@
       "id": 4499,
       "english": "agrarian, agricultural",
       "spanish": [
-        "agrario"
+        "agrario",
+        "agraria"
       ],
       "rank": 4499,
       "category": "adjective"
@@ -41122,7 +41290,8 @@
       "id": 4500,
       "english": "Swiss",
       "spanish": [
-        "suizo"
+        "suizo",
+        "suiza"
       ],
       "rank": 4500,
       "category": "adjective"
@@ -41131,7 +41300,8 @@
       "id": 4501,
       "english": "alleged, presumed",
       "spanish": [
-        "presunto"
+        "presunto",
+        "presunta"
       ],
       "rank": 4501,
       "category": "adjective"
@@ -41266,7 +41436,8 @@
       "id": 4516,
       "english": "dizzying",
       "spanish": [
-        "vertiginoso"
+        "vertiginoso",
+        "vertiginosa"
       ],
       "rank": 4516,
       "category": "adjective"
@@ -41284,7 +41455,8 @@
       "id": 4518,
       "english": "frozen",
       "spanish": [
-        "congelado"
+        "congelado",
+        "congelada"
       ],
       "rank": 4518,
       "category": "adjective"
@@ -41383,7 +41555,8 @@
       "id": 4529,
       "english": "unsure, unsafe",
       "spanish": [
-        "inseguro"
+        "inseguro",
+        "insegura"
       ],
       "rank": 4529,
       "category": "adjective"
@@ -41446,7 +41619,8 @@
       "id": 4536,
       "english": "ironic, mocking",
       "spanish": [
-        "irónico"
+        "irónico",
+        "irónica"
       ],
       "rank": 4536,
       "category": "adjective"
@@ -41491,7 +41665,8 @@
       "id": 4541,
       "english": "amazed, bewildered",
       "spanish": [
-        "asombrado"
+        "asombrado",
+        "asombrada"
       ],
       "rank": 4541,
       "category": "adjective"
@@ -41536,7 +41711,8 @@
       "id": 4546,
       "english": "sophisticated",
       "spanish": [
-        "sofisticado"
+        "sofisticado",
+        "sofisticada"
       ],
       "rank": 4546,
       "category": "adjective"
@@ -41563,7 +41739,8 @@
       "id": 4549,
       "english": "ingenious, clever",
       "spanish": [
-        "ingenioso"
+        "ingenioso",
+        "ingeniosa"
       ],
       "rank": 4549,
       "category": "adjective"
@@ -41635,7 +41812,8 @@
       "id": 4557,
       "english": "geometric",
       "spanish": [
-        "geométrico"
+        "geométrico",
+        "geométrica"
       ],
       "rank": 4557,
       "category": "adjective"
@@ -41662,7 +41840,8 @@
       "id": 4560,
       "english": "blessed",
       "spanish": [
-        "bendito"
+        "bendito",
+        "bendita"
       ],
       "rank": 4560,
       "category": "adjective"
@@ -41716,7 +41895,8 @@
       "id": 4566,
       "english": "very small, tiny",
       "spanish": [
-        "pequeñito"
+        "pequeñito",
+        "pequeñita"
       ],
       "rank": 4566,
       "category": "adjective"
@@ -41752,7 +41932,8 @@
       "id": 4570,
       "english": "fleeting, transitory",
       "spanish": [
-        "pasajero"
+        "pasajero",
+        "pasajera"
       ],
       "rank": 4570,
       "category": "adjective"
@@ -41770,7 +41951,8 @@
       "id": 4572,
       "english": "tourist",
       "spanish": [
-        "turístico"
+        "turístico",
+        "turística"
       ],
       "rank": 4572,
       "category": "adjective"
@@ -41806,7 +41988,8 @@
       "id": 4576,
       "english": "proud, arrogant",
       "spanish": [
-        "soberbio"
+        "soberbio",
+        "soberbia"
       ],
       "rank": 4576,
       "category": "adjective"
@@ -41851,7 +42034,8 @@
       "id": 4581,
       "english": "void, null",
       "spanish": [
-        "nulo"
+        "nulo",
+        "nula"
       ],
       "rank": 4581,
       "category": "adjective"
@@ -41923,7 +42107,8 @@
       "id": 4589,
       "english": "productive, profitable",
       "spanish": [
-        "productivo"
+        "productivo",
+        "productiva"
       ],
       "rank": 4589,
       "category": "adjective"
@@ -41986,7 +42171,8 @@
       "id": 4596,
       "english": "vigorous, strong",
       "spanish": [
-        "vigoroso"
+        "vigoroso",
+        "vigorosa"
       ],
       "rank": 4596,
       "category": "adjective"
@@ -42067,7 +42253,8 @@
       "id": 4605,
       "english": "delicious, tasty",
       "spanish": [
-        "sabroso"
+        "sabroso",
+        "sabrosa"
       ],
       "rank": 4605,
       "category": "adjective"
@@ -42094,7 +42281,8 @@
       "id": 4608,
       "english": "very long",
       "spanish": [
-        "larguísimo"
+        "larguísimo",
+        "larguísima"
       ],
       "rank": 4608,
       "category": "adjective"
@@ -42103,7 +42291,8 @@
       "id": 4609,
       "english": "simultaneous",
       "spanish": [
-        "simultáneo"
+        "simultáneo",
+        "simultánea"
       ],
       "rank": 4609,
       "category": "adjective"
@@ -42148,7 +42337,8 @@
       "id": 4614,
       "english": "red, colored",
       "spanish": [
-        "colorado"
+        "colorado",
+        "colorada"
       ],
       "rank": 4614,
       "category": "adjective"
@@ -42202,7 +42392,8 @@
       "id": 4620,
       "english": "prestigious",
       "spanish": [
-        "prestigioso"
+        "prestigioso",
+        "prestigiosa"
       ],
       "rank": 4620,
       "category": "adjective"
@@ -42220,7 +42411,8 @@
       "id": 4622,
       "english": "chronic",
       "spanish": [
-        "crónico"
+        "crónico",
+        "crónica"
       ],
       "rank": 4622,
       "category": "adjective"
@@ -42247,7 +42439,8 @@
       "id": 4625,
       "english": "biblical",
       "spanish": [
-        "bíblico"
+        "bíblico",
+        "bíblica"
       ],
       "rank": 4625,
       "category": "adjective"
@@ -42274,7 +42467,8 @@
       "id": 4628,
       "english": "paternal",
       "spanish": [
-        "paterno"
+        "paterno",
+        "paterna"
       ],
       "rank": 4628,
       "category": "adjective"
@@ -42319,7 +42513,8 @@
       "id": 4633,
       "english": "accelerated, quick",
       "spanish": [
-        "acelerado"
+        "acelerado",
+        "acelerada"
       ],
       "rank": 4633,
       "category": "adjective"
@@ -42328,7 +42523,8 @@
       "id": 4634,
       "english": "arid, dry",
       "spanish": [
-        "árido"
+        "árido",
+        "árida"
       ],
       "rank": 4634,
       "category": "adjective"
@@ -42337,7 +42533,8 @@
       "id": 4635,
       "english": "capricious, whimsical",
       "spanish": [
-        "caprichoso"
+        "caprichoso",
+        "caprichosa"
       ],
       "rank": 4635,
       "category": "adjective"
@@ -42346,7 +42543,8 @@
       "id": 4636,
       "english": "minute, insignificant",
       "spanish": [
-        "minúsculo"
+        "minúsculo",
+        "minúscula"
       ],
       "rank": 4636,
       "category": "adjective"
@@ -42634,7 +42832,8 @@
       "id": 4668,
       "english": "anguished, distressed",
       "spanish": [
-        "angustiado"
+        "angustiado",
+        "angustiada"
       ],
       "rank": 4668,
       "category": "adjective"
@@ -42661,7 +42860,8 @@
       "id": 4671,
       "english": "devout, pious, merciful",
       "spanish": [
-        "piadoso"
+        "piadoso",
+        "piadosa"
       ],
       "rank": 4671,
       "category": "adjective"
@@ -42688,7 +42888,8 @@
       "id": 4674,
       "english": "unlimited",
       "spanish": [
-        "ilimitado"
+        "ilimitado",
+        "ilimitada"
       ],
       "rank": 4674,
       "category": "adjective"
@@ -42724,7 +42925,8 @@
       "id": 4678,
       "english": "sporadic",
       "spanish": [
-        "esporádico"
+        "esporádico",
+        "esporádica"
       ],
       "rank": 4678,
       "category": "adjective"
@@ -42778,7 +42980,8 @@
       "id": 4684,
       "english": "melancholy",
       "spanish": [
-        "melancólico"
+        "melancólico",
+        "melancólica"
       ],
       "rank": 4684,
       "category": "adjective"
@@ -42796,7 +42999,8 @@
       "id": 4686,
       "english": "mobile",
       "spanish": [
-        "móvil"
+        "móvil",
+        "celular"
       ],
       "rank": 4686,
       "category": "adjective"
@@ -42823,7 +43027,8 @@
       "id": 4689,
       "english": "strong, robust, sturdy",
       "spanish": [
-        "robusto"
+        "robusto",
+        "robusta"
       ],
       "rank": 4689,
       "category": "adjective"
@@ -42868,7 +43073,8 @@
       "id": 4694,
       "english": "flat, level, plain",
       "spanish": [
-        "llano"
+        "llano",
+        "llana"
       ],
       "rank": 4694,
       "category": "adjective"
@@ -42877,7 +43083,8 @@
       "id": 4695,
       "english": "Colombian",
       "spanish": [
-        "colombiano"
+        "colombiano",
+        "colombiana"
       ],
       "rank": 4695,
       "category": "adjective"
@@ -42913,7 +43120,8 @@
       "id": 4699,
       "english": "distressing",
       "spanish": [
-        "angustioso"
+        "angustioso",
+        "angustiosa"
       ],
       "rank": 4699,
       "category": "adjective"
@@ -42985,7 +43193,8 @@
       "id": 4707,
       "english": "statistical",
       "spanish": [
-        "estadístico"
+        "estadístico",
+        "estadística"
       ],
       "rank": 4707,
       "category": "adjective"
@@ -43012,7 +43221,8 @@
       "id": 4710,
       "english": "evil, malignant",
       "spanish": [
-        "maligno"
+        "maligno",
+        "maligna"
       ],
       "rank": 4710,
       "category": "adjective"
@@ -43039,7 +43249,8 @@
       "id": 4713,
       "english": "understanding",
       "spanish": [
-        "comprensivo"
+        "comprensivo",
+        "comprensiva"
       ],
       "rank": 4713,
       "category": "adjective"
@@ -43048,7 +43259,8 @@
       "id": 4714,
       "english": "hollow",
       "spanish": [
-        "hueco"
+        "hueco",
+        "hueca"
       ],
       "rank": 4714,
       "category": "adjective"
@@ -43237,7 +43449,8 @@
       "id": 4735,
       "english": "bank, banking",
       "spanish": [
-        "bancario"
+        "bancario",
+        "bancaria"
       ],
       "rank": 4735,
       "category": "adjective"
@@ -43255,7 +43468,8 @@
       "id": 4737,
       "english": "walk, gait, pace",
       "spanish": [
-        "andar"
+        "andar",
+        "caminar"
       ],
       "rank": 4737,
       "category": "noun"
@@ -43273,7 +43487,8 @@
       "id": 4739,
       "english": "fortunate",
       "spanish": [
-        "afortunado"
+        "afortunado",
+        "afortunada"
       ],
       "rank": 4739,
       "category": "adjective"
@@ -43318,7 +43533,8 @@
       "id": 4744,
       "english": "informative",
       "spanish": [
-        "informativo"
+        "informativo",
+        "informativa"
       ],
       "rank": 4744,
       "category": "adjective"
@@ -43399,7 +43615,8 @@
       "id": 4753,
       "english": "imported",
       "spanish": [
-        "importado"
+        "importado",
+        "importada"
       ],
       "rank": 4753,
       "category": "adjective"
@@ -43408,7 +43625,8 @@
       "id": 4754,
       "english": "whole, entire, honest",
       "spanish": [
-        "íntegro"
+        "íntegro",
+        "íntegra"
       ],
       "rank": 4754,
       "category": "adjective"
@@ -43426,7 +43644,8 @@
       "id": 4756,
       "english": "extra",
       "spanish": [
-        "extra"
+        "extra",
+        "extro"
       ],
       "rank": 4756,
       "category": "adjective"
@@ -43471,7 +43690,8 @@
       "id": 4761,
       "english": "reciprocal",
       "spanish": [
-        "recíproco"
+        "recíproco",
+        "recíproca"
       ],
       "rank": 4761,
       "category": "adjective"
@@ -43534,7 +43754,8 @@
       "id": 4768,
       "english": "well-to-do, suitable",
       "spanish": [
-        "acomodado"
+        "acomodado",
+        "acomodada"
       ],
       "rank": 4768,
       "category": "adjective"
@@ -43660,7 +43881,8 @@
       "id": 4782,
       "english": "sovereign, self-assured",
       "spanish": [
-        "soberano"
+        "soberano",
+        "soberana"
       ],
       "rank": 4782,
       "category": "adjective"
@@ -43705,7 +43927,8 @@
       "id": 4787,
       "english": "warrior, warlike",
       "spanish": [
-        "guerrero"
+        "guerrero",
+        "guerrera"
       ],
       "rank": 4787,
       "category": "adjective"
@@ -43732,7 +43955,8 @@
       "id": 4790,
       "english": "involuntary",
       "spanish": [
-        "involuntario"
+        "involuntario",
+        "involuntaria"
       ],
       "rank": 4790,
       "category": "adjective"
@@ -43759,7 +43983,8 @@
       "id": 4793,
       "english": "subjective",
       "spanish": [
-        "subjetivo"
+        "subjetivo",
+        "subjetiva"
       ],
       "rank": 4793,
       "category": "adjective"
@@ -43831,7 +44056,8 @@
       "id": 4801,
       "english": "neutral",
       "spanish": [
-        "neutro"
+        "neutro",
+        "neutra"
       ],
       "rank": 4801,
       "category": "adjective"
@@ -43894,7 +44120,8 @@
       "id": 4808,
       "english": "disoriented",
       "spanish": [
-        "desconcertado"
+        "desconcertado",
+        "desconcertada"
       ],
       "rank": 4808,
       "category": "adjective"
@@ -44047,7 +44274,8 @@
       "id": 4825,
       "english": "imprecise",
       "spanish": [
-        "impreciso"
+        "impreciso",
+        "imprecisa"
       ],
       "rank": 4825,
       "category": "adjective"
@@ -44200,7 +44428,8 @@
       "id": 4842,
       "english": "monstrous",
       "spanish": [
-        "monstruoso"
+        "monstruoso",
+        "monstruosa"
       ],
       "rank": 4842,
       "category": "adjective"
@@ -44236,7 +44465,8 @@
       "id": 4846,
       "english": "educated",
       "spanish": [
-        "educado"
+        "educado",
+        "educada"
       ],
       "rank": 4846,
       "category": "adjective"
@@ -44299,7 +44529,8 @@
       "id": 4853,
       "english": "premature",
       "spanish": [
-        "prematuro"
+        "prematuro",
+        "prematura"
       ],
       "rank": 4853,
       "category": "adjective"
@@ -44353,7 +44584,8 @@
       "id": 4859,
       "english": "rude, crude, coarse",
       "spanish": [
-        "rudo"
+        "rudo",
+        "ruda"
       ],
       "rank": 4859,
       "category": "adjective"
@@ -44398,7 +44630,8 @@
       "id": 4864,
       "english": "pedagogical, teaching",
       "spanish": [
-        "pedagógico"
+        "pedagógico",
+        "pedagógica"
       ],
       "rank": 4864,
       "category": "adjective"
@@ -44488,7 +44721,8 @@
       "id": 4874,
       "english": "grotesque, ridiculous",
       "spanish": [
-        "grotesco"
+        "grotesco",
+        "grotesca"
       ],
       "rank": 4874,
       "category": "adjective"
@@ -44506,7 +44740,8 @@
       "id": 4876,
       "english": "sunken, drowned",
       "spanish": [
-        "sumido"
+        "sumido",
+        "sumida"
       ],
       "rank": 4876,
       "category": "adjective"
@@ -44542,7 +44777,8 @@
       "id": 4880,
       "english": "sinister",
       "spanish": [
-        "siniestro"
+        "siniestro",
+        "siniestra"
       ],
       "rank": 4880,
       "category": "adjective"
@@ -44551,7 +44787,8 @@
       "id": 4881,
       "english": "mystical infantil",
       "spanish": [
-        "místico"
+        "místico",
+        "mística"
       ],
       "rank": 4881,
       "category": "adjective"
@@ -44578,7 +44815,8 @@
       "id": 4884,
       "english": "exempt, free",
       "spanish": [
-        "exento"
+        "exento",
+        "exenta"
       ],
       "rank": 4884,
       "category": "adjective"
@@ -44605,7 +44843,8 @@
       "id": 4887,
       "english": "clinical",
       "spanish": [
-        "clínico"
+        "clínico",
+        "clínica"
       ],
       "rank": 4887,
       "category": "adjective"
@@ -44623,7 +44862,8 @@
       "id": 4889,
       "english": "of the street",
       "spanish": [
-        "callejero"
+        "callejero",
+        "callejera"
       ],
       "rank": 4889,
       "category": "adjective"
@@ -44722,7 +44962,8 @@
       "id": 4900,
       "english": "very same",
       "spanish": [
-        "mismísimo"
+        "mismísimo",
+        "mismísima"
       ],
       "rank": 4900,
       "category": "adjective"
@@ -44767,7 +45008,8 @@
       "id": 4905,
       "english": "seventh",
       "spanish": [
-        "séptimo"
+        "séptimo",
+        "séptima"
       ],
       "rank": 4905,
       "category": "adjective"
@@ -44794,7 +45036,8 @@
       "id": 4908,
       "english": "clear, clean, neat",
       "spanish": [
-        "nítido"
+        "nítido",
+        "nítida"
       ],
       "rank": 4908,
       "category": "adjective"
@@ -45046,7 +45289,8 @@
       "id": 4936,
       "english": "trivial, frivolous",
       "spanish": [
-        "frívolo"
+        "frívolo",
+        "frívola"
       ],
       "rank": 4936,
       "category": "adjective"
@@ -45064,7 +45308,8 @@
       "id": 4938,
       "english": "prodigious, famous",
       "spanish": [
-        "prodigioso"
+        "prodigioso",
+        "prodigiosa"
       ],
       "rank": 4938,
       "category": "adjective"
@@ -45091,7 +45336,8 @@
       "id": 4941,
       "english": "laborious, industrious",
       "spanish": [
-        "laborioso"
+        "laborioso",
+        "laboriosa"
       ],
       "rank": 4941,
       "category": "adjective"
@@ -45100,7 +45346,8 @@
       "id": 4942,
       "english": "ecclesiastical",
       "spanish": [
-        "eclesiástico"
+        "eclesiástico",
+        "eclesiástica"
       ],
       "rank": 4942,
       "category": "adjective"
@@ -45109,7 +45356,8 @@
       "id": 4943,
       "english": "confused",
       "spanish": [
-        "confundido"
+        "confundido",
+        "confundida"
       ],
       "rank": 4943,
       "category": "adjective"
@@ -45208,7 +45456,8 @@
       "id": 4954,
       "english": "synthetic",
       "spanish": [
-        "sintético"
+        "sintético",
+        "sintética"
       ],
       "rank": 4954,
       "category": "adjective"
@@ -45217,7 +45466,8 @@
       "id": 4955,
       "english": "warlike",
       "spanish": [
-        "bélico"
+        "bélico",
+        "bélica"
       ],
       "rank": 4955,
       "category": "adjective"
@@ -45226,7 +45476,8 @@
       "id": 4956,
       "english": "combined",
       "spanish": [
-        "combinado"
+        "combinado",
+        "combinada"
       ],
       "rank": 4956,
       "category": "adjective"
@@ -45271,7 +45522,8 @@
       "id": 4961,
       "english": "parliamentary",
       "spanish": [
-        "parlamentario"
+        "parlamentario",
+        "parlamentaria"
       ],
       "rank": 4961,
       "category": "adjective"
@@ -45280,7 +45532,8 @@
       "id": 4962,
       "english": "behind, back",
       "spanish": [
-        "trasero"
+        "trasero",
+        "trasera"
       ],
       "rank": 4962,
       "category": "adjective"
@@ -45352,7 +45605,8 @@
       "id": 4970,
       "english": "enthusiastic",
       "spanish": [
-        "entusiasta"
+        "entusiasta",
+        "entusiasto"
       ],
       "rank": 4970,
       "category": "adjective"
@@ -45370,7 +45624,8 @@
       "id": 4972,
       "english": "patriotic",
       "spanish": [
-        "patriótico"
+        "patriótico",
+        "patriótica"
       ],
       "rank": 4972,
       "category": "adjective"
@@ -45406,7 +45661,8 @@
       "id": 4976,
       "english": "crushed, flattened",
       "spanish": [
-        "aplastado"
+        "aplastado",
+        "aplastada"
       ],
       "rank": 4976,
       "category": "adjective"
@@ -45424,7 +45680,8 @@
       "id": 4978,
       "english": "rhythmic",
       "spanish": [
-        "rítmico"
+        "rítmico",
+        "rítmica"
       ],
       "rank": 4978,
       "category": "adjective"
@@ -45469,7 +45726,8 @@
       "id": 4983,
       "english": "Hispanic",
       "spanish": [
-        "hispano"
+        "hispano",
+        "hispana"
       ],
       "rank": 4983,
       "category": "adjective"
@@ -45487,7 +45745,8 @@
       "id": 4985,
       "english": "constructive",
       "spanish": [
-        "constructivo"
+        "constructivo",
+        "constructiva"
       ],
       "rank": 4985,
       "category": "adjective"


### PR DESCRIPTION
Ran add_variants.py script on words 3501-5000, modifying 257 entries. Adds masculine/feminine variants for adjectives and common Spanish synonyms.

https://claude.ai/code/session_01SsY2SbBQZ6UmQdTR1SpHDd