### PR TITLE
Fix JSON syntax errors in words.json causing app to fail to load

### DIFF
--- a/words.json
+++ b/words.json
@@ -577,7 +577,7 @@
       "spanish": [
         "eso",
         "ese",
-        "esa",
+        "esa"
       ],
       "rank": 63,
       "category": "pronoun"
@@ -6445,7 +6445,7 @@
       "english": "behind",
       "spanish": [
         "detrás",
-        "atrás,
+        "atrás",
         "tras"
       ],
       "rank": 701,
@@ -11062,7 +11062,7 @@
       "english": "to go, leave, march",
       "spanish": [
         "marchar",
-        "andar",
+        "andar"
       ],
       "rank": 1203,
       "category": "verb"


### PR DESCRIPTION
Two trailing commas and a missing closing quote were causing the entire words.json to fail parsing, which broke all API endpoints and produced the "Error loading word. Please refresh." error.

https://claude.ai/code/session_015NBQXpeQ29qEh1vpifD2b1