### PR TITLE
Fix JSON syntax errors in words.json causing word loading failure

### DIFF
--- a/words.json
+++ b/words.json
@@ -10678,7 +10678,7 @@
       "id": 1161,
       "english": "to distribute, divide, give out",
       "spanish": [
-        "repartir",
+        "repartir"
       ],
       "rank": 1161,
       "category": "verb"
@@ -10688,7 +10688,7 @@
       "english": "start, beginning",
       "spanish": [
         "comienzo",
-        "empiezo
+        "empiezo"
       ],
       "rank": 1162,
       "category": "noun"


### PR DESCRIPTION
Two issues in words.json prevented the file from parsing:
1. Trailing comma after "repartir" in the spanish array for word ID 1161
2. Missing closing quote on "empiezo" for word ID 1162

These errors caused json.load() to fail, which made /api/words return an error and displayed "Error loading words. Please refresh." in the UI.

https://claude.ai/code/session_015SjtN2xjhmTi9bbHuksyjh