### PR TITLE
Fix theme persistence and Spain/Colombia flag previews on mobile

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -78,6 +78,8 @@ function initProgress() {
     }
     if (!localProgress.settings) localProgress.settings = {};
     currentLevel = localProgress.settings.level || 1;
+    currentTheme = localProgress.settings.theme || 'default';
+    applyTheme(currentTheme);
 }
 
 function saveLocalProgress() {
@@ -547,6 +549,8 @@ async function setTheme(theme) {
             body: JSON.stringify({ theme })
         });
         currentTheme = theme;
+        localProgress.settings.theme = theme;
+        saveLocalProgress();
         applyTheme(theme);
         updateThemeUI();
         closeThemeModal();

--- a/static/style.css
+++ b/static/style.css
@@ -918,10 +918,10 @@ footer {
 }
 
 .default-preview            { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }
-.spain-preview              { background: linear-gradient(135deg, #c60b1e 0%, #ffc400 100%); }
+.spain-preview              { background: linear-gradient(to bottom, #c60b1e 25%, #ffc400 25% 75%, #c60b1e 75%); }
 .mexico-preview             { background: linear-gradient(135deg, #006847 0%, #ce1126 100%); }
 .costa-rica-preview         { background: linear-gradient(135deg, #023e8a 0%, #ce1126 100%); }
-.colombia-preview           { background: linear-gradient(90deg, #fcd116 33%, #003087 33% 66%, #ce1126 66%); }
+.colombia-preview           { background: linear-gradient(to bottom, #fcd116 50%, #003087 50% 75%, #ce1126 75%); }
 .dominican-republic-preview { background: linear-gradient(135deg, #002D62 0%, #CE1126 100%); }
 
 .theme-flag {


### PR DESCRIPTION
Theme saving:
- Store selected theme in localProgress.settings.theme (localStorage)
- Apply theme immediately from localStorage in initProgress() so it loads without waiting for the /api/settings network request
- Save to localStorage in setTheme() alongside the server POST

Flag previews:
- Spain preview: replace diagonal gradient with proper 3-stripe flag pattern (red | yellow | red) using hard-stop top-to-bottom gradient
- Colombia preview: replace left-to-right stripes with top-to-bottom flag pattern (yellow | blue | red) — all 3 colors now visible at any preview size including small mobile layouts

https://claude.ai/code/session_015SjtN2xjhmTi9bbHuksyjh