### PR TITLE
Fix JSON syntax errors in words.json causing 'Error loading words.'

### DIFF
--- a/words.json
+++ b/words.json
@@ -12657,8 +12657,8 @@
         "bella",
         "bonito",
         "lindo",
-        "linda"'
-        "hermosa"
+        "linda",
+        "hermosa",
         "hermoso"
       ],
       "rank": 1338,
@@ -13996,7 +13996,7 @@
       "id": 1478,
       "english": "moment, while, time",
       "spanish": [
-        "rato",
+        "rato"
       ],
       "rank": 1478,
       "category": "noun",


### PR DESCRIPTION
Two errors were present:
- Line 12660: stray single-quote after "linda" and missing commas on subsequent entries
- Line 13999: trailing comma after last array element "rato"

https://claude.ai/code/session_017y778LBJC9BDkHbtF6f7wr